### PR TITLE
Add GLB drag support

### DIFF
--- a/examples/playground/index.html
+++ b/examples/playground/index.html
@@ -188,9 +188,9 @@
 
           const files = e.dataTransfer.files; // Array of all files.
 
-          for (let i = 0, file; file = files[i]; i++) {
+          for (const file of files) {
               // Process only GLB files.
-              if (file.name.match(/\.(glb)$/)) {
+              if (file.name.endsWith(".glb")) {
                   const reader = new FileReader();
 
                   reader.onload = (function(theFile) {

--- a/examples/playground/index.html
+++ b/examples/playground/index.html
@@ -204,34 +204,40 @@
 
     <script>
       // Add the drag and drop event listeners to the document and process a dragged GLB file.
-      document.addEventListener("dragover", function(e) {
+      document.addEventListener(
+        "dragover",
+        function (e) {
           e.stopPropagation();
           e.preventDefault();
           e.dataTransfer.dropEffect = "copy";
-      }, false);
+        },
+        false
+      );
 
-      document.addEventListener("drop", function(e) {
+      document.addEventListener(
+        "drop",
+        function (e) {
           e.stopPropagation();
           e.preventDefault();
 
           const files = e.dataTransfer.files; // Array of all files.
 
           for (const file of files) {
-              // Process only GLB files.
-              if (file.name.endsWith(".glb")) {
-                  const reader = new FileReader();
+            // Process only GLB files.
+            if (file.name.endsWith(".glb")) {
+              const reader = new FileReader();
 
-                  reader.onload = (function(theFile) {
-                      return function(e) {
-                          // Set the gltf-model-plus attribute of the gltf-model-plus component to the dropped file.
-                          document.querySelector("[gltf-model-plus]").setAttribute("gltf-model-plus", e.target.result);
-                      };
-                  })(file);
+              reader.onload = function (e) {
+                // Set the gltf-model-plus attribute of the gltf-model-plus component to the dropped file.
+                document.querySelector("[gltf-model-plus]").setAttribute("gltf-model-plus", e.target.result);
+              };
 
-                  reader.readAsDataURL(file);
-              }
+              reader.readAsDataURL(file);
+            }
           }
-      }, false);
-  </script>
+        },
+        false
+      );
+    </script>
   </body>
 </html>

--- a/examples/playground/index.html
+++ b/examples/playground/index.html
@@ -173,5 +173,37 @@
 
       <a-entity light="type: point; color: #f4f4f4; intensity: 0.4; distance: 0" position="0 2 0"></a-entity>
     </a-scene>
+
+    <script>
+      // Add the drag and drop event listeners to the document and process a dragged GLB file.
+      document.addEventListener("dragover", function(e) {
+          e.stopPropagation();
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "copy";
+      }, false);
+
+      document.addEventListener("drop", function(e) {
+          e.stopPropagation();
+          e.preventDefault();
+
+          const files = e.dataTransfer.files; // Array of all files.
+
+          for (let i = 0, file; file = files[i]; i++) {
+              // Process only GLB files.
+              if (file.name.match(/\.(glb)$/)) {
+                  const reader = new FileReader();
+
+                  reader.onload = (function(theFile) {
+                      return function(e) {
+                          // Set the gltf-model-plus attribute of the gltf-model-plus component to the dropped file.
+                          document.querySelector("[gltf-model-plus]").setAttribute("gltf-model-plus", e.target.result);
+                      };
+                  })(file);
+
+                  reader.readAsDataURL(file);
+              }
+          }
+      }, false);
+  </script>
   </body>
 </html>


### PR DESCRIPTION
Hi Vincent,

I am missing the Hubs Blender Plugin easy GLB workflow. So I took your ticket #32 »Implement drag and drop scene glb for development #32« and added Drag and Drop in index.html. Please have a look, if the implementation is ok for you.