### PR TITLE
emit waypoints-ready when really all waypoints are created

### DIFF
--- a/src/components/gltf-model-plus.js
+++ b/src/components/gltf-model-plus.js
@@ -254,6 +254,8 @@ export const gltfModelPlus = {
       return;
     }
 
+    el.sceneEl.systems.waypoint.glbLoading += 1;
+    console.log("[wp] increment glbLoading", el.sceneEl.systems.waypoint.glbLoading);
     this.ready.then(function () {
       self.el.emit("model-loading", { src });
       self.loader.load(
@@ -346,6 +348,10 @@ export const gltfModelPlus = {
             }
           });
 
+          // Need to be decremented before executing finalizer that create waypoints
+          el.sceneEl.systems.waypoint.glbLoading -= 1;
+          console.log("[wp] decrement glbLoading", el.sceneEl.systems.waypoint.glbLoading);
+
           for (let i = 0; i < finalizers.length; i++) {
             finalizers[i]();
           }
@@ -360,9 +366,6 @@ export const gltfModelPlus = {
           // el could be a FakeEntity if we aliased gtlf-model to gtlf-model-plus, so we check classList is not undefined
           if (el.classList?.contains("environment-settings")) {
             gltfInflators.get("environment-settings")(el.sceneEl, environmentSettings);
-            queueMicrotask(() => {
-              el.sceneEl.emit("waypoints-ready");
-            });
           }
 
           setTimeout(() => {

--- a/src/components/waypoint.js
+++ b/src/components/waypoint.js
@@ -44,6 +44,24 @@ AFRAME.registerSystem("waypoint", {
     this.occupyWaypoint = false;
     this.showClickableWaypoints = false;
     this.registeredWaypoints = [];
+    this.glbLoading = 0;
+    this.pendingEmitWaypointsReady = false;
+  },
+  scheduleEmitWaypointsReady() {
+    if (this.pendingEmitWaypointsReady) return;
+    this.pendingEmitWaypointsReady = true;
+    console.log("[wp] schedule emitting waypoints-ready in a microtask");
+    queueMicrotask(() => {
+      if (this.glbLoading > 0) {
+        console.log(`[wp] ${this.glbLoading} glb still loading, cancel emitting waypoints-ready`);
+        this.pendingEmitWaypointsReady = false;
+        return;
+      }
+
+      console.log("[wp] emit waypoints-ready");
+      this.el.emit("waypoints-ready");
+      this.pendingEmitWaypointsReady = false;
+    });
   },
   toggleClickableWaypoints() {
     this.showClickableWaypoints = !this.showClickableWaypoints;
@@ -211,6 +229,8 @@ AFRAME.registerComponent("waypoint", {
     const idx = this.system.registeredWaypoints.indexOf(this.el);
     if (idx === -1) {
       this.system.registeredWaypoints.push(this.el);
+      console.log("[wp] register waypoint");
+      this.system.scheduleEmitWaypointsReady();
     }
   },
   unregisterWaypoint() {


### PR DESCRIPTION
emit waypoints-ready when all gltf-model-plus components are loaded and all a-waypoint are created (fix #46)