### PR TITLE
Fix video-texture-target reacting to share_video_enabled events for other entities

### DIFF
--- a/src/components/video-texture-target.js
+++ b/src/components/video-texture-target.js
@@ -228,6 +228,13 @@ AFRAME.registerComponent("video-texture-target", {
   },
 
   startVideoSharing(evt) {
+    if (evt.detail.el !== this.el) {
+      // share_video_enabled is a scene-level event, it fires on every
+      // video-texture-target instance. Only react if the share targets this
+      // entity, otherwise we would set isVideoSharing and take ownership of
+      // entities used by other participants.
+      return;
+    }
     this.isVideoSharing = true;
     this.mediaSourceUsed = evt.detail.source;
 


### PR DESCRIPTION
## Problem

`share_video_enabled` is a scene-level event, so `startVideoSharing` fired on **every** `video-texture-target` instance in the scene, not just the entity being used for the share. Each instance set `isVideoSharing = true` and called `NAF.utils.takeOwnership()` on its networked entity.

With several `video-texture-target` instances in a scene (e.g. one plane per participant), starting any video share stole ownership of every other participant's entity. Consequences:

- Stopping a share ran `stopVideoSharing` on all instances where `isVideoSharing && isMine` (all of them, due to the ownership theft), resetting `src=""` on other participants' entities and ending their video for the whole room.
- When another participant's `src` sync arrived on an instance with `isVideoSharing` wrongly true, the "Somebody used the same element than us" branch in `update()` ended our own share.
- Stolen ownership silently broke the original owner's component syncs (and anything derived from `networked.data.owner`, like `networked-audio-source` stream lookup for late joiners).

## Fix

`startVideoSharing` now returns early unless `evt.detail.el === this.el`.

## Breaking change

The application emitting `share_video_enabled` must now include the target entity in the event detail:

```js
sceneEl.emit("share_video_enabled", { source, el: videoShareEntity });
```

Without `el`, the component ignores the event and no longer takes ownership of the entity, so the share won't propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)